### PR TITLE
Add trimming module and generate pre/post trimming multiqc reports

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -10,6 +10,11 @@
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
                         "installed_by": ["modules"]
                     },
+                    "cutadapt": {
+                        "branch": "master",
+                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
+                        "installed_by": ["modules"]
+                    },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",

--- a/modules/nf-core/cutadapt/main.nf
+++ b/modules/nf-core/cutadapt/main.nf
@@ -1,0 +1,37 @@
+process CUTADAPT {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "bioconda::cutadapt=3.4"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/cutadapt:3.4--py39h38f01e4_1' :
+        'quay.io/biocontainers/cutadapt:3.4--py39h38f01e4_1' }"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path('*.trim.fastq.gz'), emit: reads
+    tuple val(meta), path('*.log')          , emit: log
+    path "versions.yml"                     , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def trimmed  = meta.single_end ? "-o ${prefix}.trim.fastq.gz" : "-o ${prefix}_1.trim.fastq.gz -p ${prefix}_2.trim.fastq.gz"
+    """
+    cutadapt \\
+        --cores $task.cpus \\
+        $args \\
+        $trimmed \\
+        $reads \\
+        > ${prefix}.cutadapt.log
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        cutadapt: \$(cutadapt --version)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/cutadapt/meta.yml
+++ b/modules/nf-core/cutadapt/meta.yml
@@ -1,0 +1,46 @@
+name: cutadapt
+description: Perform adapter/quality trimming on sequencing reads
+keywords:
+  - trimming
+  - adapter trimming
+  - adapters
+  - quality trimming
+tools:
+  - cuatadapt:
+      description: |
+        Cutadapt finds and removes adapter sequences, primers, poly-A tails and other types of unwanted sequence from your high-throughput sequencing reads.
+      documentation: https://cutadapt.readthedocs.io/en/stable/index.html
+      doi: DOI:10.14806/ej.17.1.200
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: The trimmed/modified fastq reads
+      pattern: "*fastq.gz"
+  - log:
+      type: file
+      description: cuatadapt log file
+      pattern: "*cutadapt.log"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@drpatelh"
+  - "@kevinmenden"

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,6 +6,24 @@
 ----------------------------------------------------------------------------------------
 */
 
+process {
+    withName: CUTADAPT {
+        ext.args = '-q 25'
+    }
+
+    withName: "MULTIQC_PRE_TRIMMING" {
+            publishDir = [
+                path: { "${params.outdir}/multiqc_pre_trimming/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            ]
+        }
+    withName: "MULTIQC_POST_TRIMMING" {
+            publishDir = [
+                path: { "${params.outdir}/multiqc_post_trimming/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            ]
+        }
+}
+
+
 // Global default params, used in configs
 params {
 
@@ -58,19 +76,6 @@ params {
 
 }
 
-process {
-
-    withName: "MULTIQC_PRE_TRIMMING" {
-            publishDir = [
-                path: { "${params.outdir}/multiqc_pre_trimming/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-            ]
-        }
-    withName: "MULTIQC_POST_TRIMMING" {
-            publishDir = [
-                path: { "${params.outdir}/multiqc_post_trimming/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-            ]
-        }
-}
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,6 +58,20 @@ params {
 
 }
 
+process {
+
+    withName: "MULTIQC_PRE_TRIMMING" {
+            publishDir = [
+                path: { "${params.outdir}/multiqc_pre_trimming/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            ]
+        }
+    withName: "MULTIQC_POST_TRIMMING" {
+            publishDir = [
+                path: { "${params.outdir}/multiqc_post_trimming/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            ]
+        }
+}
+
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
 


### PR DESCRIPTION
This PR adds 
1. `cutadapt` module in the pipeline
2. Implements FASTQC and MULTIQC before and after the trimming process
3. Publishes the results of MULTIQC pre/post trimming in different locations